### PR TITLE
Updated README.md to install missing binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ macOS:
 
     $ xcode-select --install
     $ ruby -e "$(curl -fsSL git.io/get-brew)"
-    $ brew install coreutils ghostscript gnu-sed imagemagick
+    $ brew install coreutils ghostscript gnu-sed imagemagick gnu-getopt 
 
 ---
 ## ![#c5f015](images/lime.png) Outputs


### PR DESCRIPTION
Added gnu-getopt to the brew install command to make it work on macOS Mojave 10.14.6
Small fix to resolve Issue #38 