### PR TITLE
Blue color fix for macOS dark theme

### DIFF
--- a/googliser.sh
+++ b/googliser.sh
@@ -3554,7 +3554,7 @@ ColourTextBrightBlue()
     {
 
     if [[ $display_colour = true ]]; then
-        echo -en '\033[1;94m'"$(ColourReset "$1")"
+        echo -en '\033[1;34m'"$(ColourReset "$1")"
     else
         echo -n "$1"
     fi


### PR DESCRIPTION
Changing the blue color to a normal (instead of bright blue) makes colors more consistent
Issue #69 
macOS Catalina (dark theme on Terminal)
<img width="514" alt="Screenshot 2019-11-28 at 1 11 54 PM" src="https://user-images.githubusercontent.com/6491549/69809197-2ab46280-11e1-11ea-963e-9006df581341.png">
