### PR TITLE
Version and PID unreadable fix

### DIFF
--- a/googliser.sh
+++ b/googliser.sh
@@ -3477,7 +3477,7 @@ RemoveColourCodes()
 ShowTitle()
     {
 
-    [[ $verbose = true ]] && echo "$(ColourBackgroundBlack " $(ColourTextBrightWhite "$SCRIPT_FILE")")$(ColourBackgroundBlack " $SCRIPT_VERSION_PID ")"
+    [[ $verbose = true ]] && echo "$(ColourBackgroundBlack " $(ColourTextBrightWhite "$SCRIPT_FILE")")$(ColourBackgroundBlack " $(ColourTextBrightWhite "$SCRIPT_VERSION_PID")")"
 
     }
 


### PR DESCRIPTION
Color of PID and version was not set to white on background color so it was unreadable in light mode. 
Issue #80 