### PR TITLE
Bash completion path update

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -128,7 +128,6 @@ InstallCompletion()
     for target_completion_path in "${TARGET_COMPLETION_PATHS[@]}"; do
         if [[ -d $target_completion_path ]]; then
             for bash_completion_packagepath in "${BASH_COMPLETION_PACKAGEPATHS[@]}"; do
-                echo $bash_completion_packagepath
                 if [[ -f $bash_completion_packagepath ]]; then
                     WriteCompletionScript
 

--- a/install.sh
+++ b/install.sh
@@ -7,9 +7,7 @@ Init()
     readonly TARGET_SCRIPT_PATHFILE=/usr/local/bin/googliser
     readonly SOURCE_COMPLETION_PATHFILE=/tmp/googliser-completion
     TARGET_COMPLETION_PATHS=()
-    TARGET_COMPLETION_PATHS+=(/etc/bash_completion.d)
-    TARGET_COMPLETION_PATHS+=(/usr/local/etc/bash_completion.d)
-    TARGET_COMPLETION_PATHS+=(/usr/share/bash-completion/completions)
+    TARGET_COMPLETION_PATHS+=(/usr/share/bash-completion/bash_completion)
     readonly TARGET_COMPLETION_PATHS
 
     SUDO='sudo -k '         # '-k' disables cached authentication, so a password will be required every time
@@ -122,7 +120,7 @@ InstallCompletion()
     [[ $OSTYPE = "darwin"* ]] && brew install bash-completion
 
     for target_completion_path in "${TARGET_COMPLETION_PATHS[@]}"; do
-        if [[ -d $target_completion_path ]]; then
+        if [[ -f $target_completion_path ]]; then
             WriteCompletionScript
 
             # move completion script into target path

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,14 @@ Init()
     readonly SOURCE_SCRIPT_PATHFILE=/tmp/googliser.sh
     readonly TARGET_SCRIPT_PATHFILE=/usr/local/bin/googliser
     readonly SOURCE_COMPLETION_PATHFILE=/tmp/googliser-completion
+    BASH_COMPLETION_PACKAGEPATHS=()
+    BASH_COMPLETION_PACKAGEPATHS+=(/usr/share/bash-completion/bash_completion)
+    BASH_COMPLETION_PACKAGEPATHS+=(/usr/local/etc/bash_completion)
+    readonly BASH_COMPLETION_PACKAGEPATHS
     TARGET_COMPLETION_PATHS=()
-    TARGET_COMPLETION_PATHS+=(/usr/share/bash-completion/bash_completion)
+    TARGET_COMPLETION_PATHS+=(/etc/bash_completion.d)
+    TARGET_COMPLETION_PATHS+=(/usr/local/etc/bash_completion.d)
+    TARGET_COMPLETION_PATHS+=(/usr/share/bash-completion/completions)
     readonly TARGET_COMPLETION_PATHS
 
     SUDO='sudo -k '         # '-k' disables cached authentication, so a password will be required every time
@@ -120,39 +126,44 @@ InstallCompletion()
     [[ $OSTYPE = "darwin"* ]] && brew install bash-completion
 
     for target_completion_path in "${TARGET_COMPLETION_PATHS[@]}"; do
-        if [[ -f $target_completion_path ]]; then
-            WriteCompletionScript
+        if [[ -d $target_completion_path ]]; then
+            for bash_completion_packagepath in "${BASH_COMPLETION_PACKAGEPATHS[@]}"; do
+                echo $bash_completion_packagepath
+                if [[ -f $bash_completion_packagepath ]]; then
+                    WriteCompletionScript
 
-            # move completion script into target path
-            cmd="${SUDO}mv $SOURCE_COMPLETION_PATHFILE $target_completion_path"
-            [[ -n $SUDO ]] && echo " Executing: '$cmd'"
-            eval "$cmd"; cmd_result=$?
+                    # move completion script into target path
+                    cmd="${SUDO}mv $SOURCE_COMPLETION_PATHFILE $target_completion_path"
+                    [[ -n $SUDO ]] && echo " Executing: '$cmd'"
+                    eval "$cmd"; cmd_result=$?
 
-            if [[ $cmd_result -gt 0 ]]; then
-                echo " Unable to move $SOURCE_COMPLETION_PATHFILE into $target_completion_path"
-                return 1
-            fi
-
-            # now source completion script
-            case $OSTYPE in
-                darwin*)
-                    SHELL=$(ps -p $$ -o ppid= | xargs ps -o comm= -p)
-                    if [[ "$SHELL" == "zsh" ]]; then
-                        echo "autoload -Uz compinit && compinit && autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
-                        echo "source /usr/local/etc/bash_completion.d/googliser-completion" >> "$HOME/.zshrc"
-                        #. "$HOME/.zshrc"
-                    else
-                        echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> "$HOME/.bash_profile"
-                        # shellcheck disable=SC1090
-                        . "$HOME/.bash_profile"
+                    if [[ $cmd_result -gt 0 ]]; then
+                        echo " Unable to move $SOURCE_COMPLETION_PATHFILE into $target_completion_path"
+                        return 1
                     fi
-                    ;;
-                linux*)
-                    # shellcheck disable=SC1090
-                    . "$target_completion_path/googliser-completion"
-                    ;;
-            esac
-            break
+
+                    # now source completion script
+                    case $OSTYPE in
+                        darwin*)
+                            SHELL=$(ps -p $$ -o ppid= | xargs ps -o comm= -p)
+                            if [[ "$SHELL" == "zsh" ]]; then
+                                echo "autoload -Uz compinit && compinit && autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
+                                echo "source /usr/local/etc/bash_completion.d/googliser-completion" >> "$HOME/.zshrc"
+                                #. "$HOME/.zshrc"
+                            else
+                                echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> "$HOME/.bash_profile"
+                                # shellcheck disable=SC1090
+                                . "$HOME/.bash_profile"
+                            fi
+                            ;;
+                        linux*)
+                            # shellcheck disable=SC1090
+                            . "$target_completion_path/googliser-completion"
+                            ;;
+                    esac
+                    break 2
+                fi
+            done
         fi
     done
 


### PR DESCRIPTION
Checking directories doesn't because the directories exist even if the `bash-completion` package has been uninstalled. But checking for the `bash_completion` file works. 

For mac there is no need to check since we are installing `bash-completion` regardless. 

General bash completion would work without the `bash-completion` package on linux (atleast on ubuntu) but I am using `_filedir` function from the bash completion package to suggest path completion and that is only available when `bash-completion` package is installed. 

Issue #84 