### PR TITLE
Avoid duplication of entries in shell configuration file

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,14 +150,13 @@ InstallCompletion()
                                 echo "autoload -Uz compinit && compinit && autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
                                 LINE="source /usr/local/etc/bash_completion.d/googliser-completion"
                                 CONFIG_FILE="$HOME/.zshrc"
-                                #. "$HOME/.zshrc"
+                                grep -qF -- "$LINE" "$CONFIG_FILE" || echo "$LINE" >> "$CONFIG_FILE"
                             else
                                 LINE="[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion"
                                 CONFIG_FILE="$HOME/.bash_profile"
-                                # shellcheck disable=SC1090
-                                . "$HOME/.bash_profile"
+                                grep -qF -- "$LINE" "$CONFIG_FILE" || echo "$LINE" >> "$CONFIG_FILE"
+                                . $CONFIG_FILE
                             fi
-                            grep -qF -- "$LINE" "$CONFIG_FILE" || echo "$LINE" >> "$CONFIG_FILE"
                             ;;
                         linux*)
                             # shellcheck disable=SC1090

--- a/install.sh
+++ b/install.sh
@@ -148,13 +148,16 @@ InstallCompletion()
                             SHELL=$(ps -p $$ -o ppid= | xargs ps -o comm= -p)
                             if [[ "$SHELL" == "zsh" ]]; then
                                 echo "autoload -Uz compinit && compinit && autoload bashcompinit && bashcompinit" >> "$HOME/.zshrc"
-                                echo "source /usr/local/etc/bash_completion.d/googliser-completion" >> "$HOME/.zshrc"
+                                LINE="source /usr/local/etc/bash_completion.d/googliser-completion"
+                                CONFIG_FILE="$HOME/.zshrc"
                                 #. "$HOME/.zshrc"
                             else
-                                echo "[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion" >> "$HOME/.bash_profile"
+                                LINE="[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion"
+                                CONFIG_FILE="$HOME/.bash_profile"
                                 # shellcheck disable=SC1090
                                 . "$HOME/.bash_profile"
                             fi
+                            grep -qF -- "$LINE" "$CONFIG_FILE" || echo "$LINE" >> "$CONFIG_FILE"
                             ;;
                         linux*)
                             # shellcheck disable=SC1090


### PR DESCRIPTION
Check if the entry for loading bash completion file is already in the configuration file before appending the line to the configuration file.